### PR TITLE
Use proper copy args

### DIFF
--- a/openshift/from-dir-s2i-build.yaml
+++ b/openshift/from-dir-s2i-build.yaml
@@ -19,7 +19,7 @@ parameters:
 - name: ARTIFACT_COPY_ARGS
   description: Syntax to be used to copy uberjar files to the target directory
   displayName: Copy Args
-  value: '*-exec.jar'
+  value: '*.jar'
   required: true
 - name: GITHUB_WEBHOOK_SECRET
   description: A secret string used to configure the GitHub webhook.

--- a/openshift/from-git-s2i-build.yaml
+++ b/openshift/from-git-s2i-build.yaml
@@ -28,7 +28,7 @@ parameters:
 - name: ARTIFACT_COPY_ARGS
   description: Syntax to be used to copy uberjar files to the target directory
   displayName: Copy Args
-  value: '*-exec.jar'
+  value: '*.jar'
   required: true
 - name: GITHUB_WEBHOOK_SECRET
   description: A secret string used to configure the GitHub webhook.

--- a/openshift/from-jenkinsfile-s2i-build.yaml
+++ b/openshift/from-jenkinsfile-s2i-build.yaml
@@ -28,7 +28,7 @@ parameters:
 - name: ARTIFACT_COPY_ARGS
   description: Syntax to be used to copy uberjar files to the target directory
   displayName: Copy Args
-  value: '*-exec.jar'
+  value: '*.jar'
   required: true
 - name: GITHUB_WEBHOOK_SECRET
   description: A secret string used to configure the GitHub webhook.


### PR DESCRIPTION
When the project is built via Maven, the following jars are created
rest-http-2.1.3.jar and rest-http-2.1.3.jar.original
So we need to fix the copy args to take this into account